### PR TITLE
HIL (redis)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tool implementations without langchain or langgraph dependencies
 - CRUDs.
 - BlueNaas CRUD tools
+- HIL (redis)
 
 ## [0.3.3] - 30.10.2024
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pydantic-settings",
     "python-dotenv",
     "python-keycloak",
-    "redispy",
+    "redis",
     "sqlalchemy[asyncio]",
     "uvicorn",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pydantic-settings",
     "python-dotenv",
     "python-keycloak",
+    "redispy",
     "sqlalchemy[asyncio]",
     "uvicorn",
     ]

--- a/swarm_copy/app/config.py
+++ b/swarm_copy/app/config.py
@@ -17,6 +17,16 @@ class SettingsAgent(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
+class SettingsHIL(BaseModel):
+    """Agent setting."""
+
+    redis_uri: str
+    poll_interval: int = 5
+    ttl_seconds: int = 600  # 10 minutes
+
+    model_config = ConfigDict(frozen=True)
+
+
 class SettingsDB(BaseModel):
     """DB settings for retrieving history."""
 
@@ -213,6 +223,7 @@ class Settings(BaseSettings):
 
     tools: SettingsTools
     knowledge_graph: SettingsKnowledgeGraph
+    hil: SettingsHIL
     agent: SettingsAgent = SettingsAgent()  # has no required
     db: SettingsDB = SettingsDB()  # has no required
     openai: SettingsOpenAI = SettingsOpenAI()  # has no required

--- a/swarm_copy/app/config.py
+++ b/swarm_copy/app/config.py
@@ -21,8 +21,8 @@ class SettingsHIL(BaseModel):
     """Agent setting."""
 
     redis_uri: str
-    poll_interval: int = 5
-    ttl_seconds: int = 600  # 10 minutes
+    poll_interval: int = 5  # in seconds
+    ttl: int = 600  # in seconds
 
     model_config = ConfigDict(frozen=True)
 

--- a/swarm_copy/app/dependencies.py
+++ b/swarm_copy/app/dependencies.py
@@ -233,7 +233,7 @@ async def get_vlab_and_project(
 
 
 def get_starting_agent(
-    _: Annotated[None, Depends(get_vlab_and_project)],
+    # _: Annotated[None, Depends(get_vlab_and_project)],
     settings: Annotated[Settings, Depends(get_settings)],
 ) -> Agent:
     """Get the starting agent."""
@@ -309,9 +309,15 @@ async def get_redis_client(
 def get_agents_routine(
     openai: Annotated[AsyncOpenAI | None, Depends(get_openai_client)],
     redis_client: Annotated[redis.Redis, Depends(get_redis_client)],
+    settings: Annotated[Settings, Depends(get_settings)],
 ) -> AgentsRoutine:
     """Get the AgentRoutine client."""
-    return AgentsRoutine(redis_client=redis_client, client=openai)
+    return AgentsRoutine(
+        redis_client=redis_client,
+        client=openai,
+        poll_interval=settings.hil.poll_interval,
+        ttl=settings.hil.ttl,
+    )
 
 
 async def get_update_kg_hierarchy(

--- a/swarm_copy/app/dependencies.py
+++ b/swarm_copy/app/dependencies.py
@@ -14,7 +14,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from starlette.status import HTTP_401_UNAUTHORIZED
 
-
 from swarm_copy.app.app_utils import validate_project
 from swarm_copy.app.config import Settings
 from swarm_copy.app.database.sql_schemas import Threads

--- a/swarm_copy/app/dependencies.py
+++ b/swarm_copy/app/dependencies.py
@@ -268,6 +268,7 @@ def get_context_variables(
     starting_agent: Annotated[Agent, Depends(get_starting_agent)],
     token: Annotated[str, Depends(get_kg_token)],
     httpx_client: Annotated[AsyncClient, Depends(get_httpx_client)],
+    user_id: Annotated[str, Depends(get_user_id)],
 ) -> dict[str, Any]:
     """Get the global context variables to feed the tool's metadata."""
     return {
@@ -275,6 +276,7 @@ def get_context_variables(
         "token": token,
         "vlab_id": "32c83739-f39c-49d1-833f-58c981ebd2a2",  # New god account vlab. Replaced by actual id in endpoint for now. Meant for usage without history
         "project_id": "123251a1-be18-4146-87b5-5ca2f8bfaf48",  # New god account proj. Replaced by actual id in endpoint for now. Meant for usage without history
+        "user_id": user_id,
         "retriever_k": settings.tools.literature.retriever_k,
         "reranker_k": settings.tools.literature.reranker_k,
         "use_reranker": settings.tools.literature.use_reranker,

--- a/swarm_copy/app/dependencies.py
+++ b/swarm_copy/app/dependencies.py
@@ -30,6 +30,7 @@ from swarm_copy.tools import (
     MEModelGetAllTool,
     MEModelGetOneTool,
     MorphologyFeatureTool,
+    NowTool,
     ResolveEntitiesTool,
     SCSGetAllTool,
     SCSGetOneTool,
@@ -255,6 +256,7 @@ def get_starting_agent(
             MorphologyFeatureTool,
             ResolveEntitiesTool,
             GetTracesTool,
+            NowTool,
         ],
         model=settings.openai.model,
     )

--- a/swarm_copy/app/main.py
+++ b/swarm_copy/app/main.py
@@ -21,7 +21,7 @@ from swarm_copy.app.dependencies import (
     get_settings,
     get_update_kg_hierarchy,
 )
-from swarm_copy.app.routers import qa, threads, tools
+from swarm_copy.app.routers import qa, threads, tools, approvals
 
 LOGGING = {
     "version": 1,
@@ -127,6 +127,7 @@ app.add_middleware(
 app.include_router(qa.router)
 app.include_router(threads.router)
 app.include_router(tools.router)
+app.include_router(approvals.router)
 
 
 @app.get("/healthz")

--- a/swarm_copy/app/main.py
+++ b/swarm_copy/app/main.py
@@ -21,7 +21,7 @@ from swarm_copy.app.dependencies import (
     get_settings,
     get_update_kg_hierarchy,
 )
-from swarm_copy.app.routers import qa, threads, tools, approvals
+from swarm_copy.app.routers import approvals, qa, threads, tools
 
 LOGGING = {
     "version": 1,

--- a/swarm_copy/app/routers/approvals.py
+++ b/swarm_copy/app/routers/approvals.py
@@ -3,9 +3,9 @@
 import json
 import logging
 from typing import Annotated, Literal
-from pydantic import BaseModel
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 from redis.asyncio import Redis
 
 from swarm_copy.app.dependencies import (

--- a/swarm_copy/app/routers/approvals.py
+++ b/swarm_copy/app/routers/approvals.py
@@ -1,0 +1,134 @@
+"""Approvals CRUDs."""
+
+import json
+import logging
+from typing import Annotated, Literal
+from pydantic import BaseModel
+
+from fastapi import APIRouter, Depends, HTTPException
+from redis.asyncio import Redis
+
+from swarm_copy.app.dependencies import (
+    get_redis_client,
+    get_user_id,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/approvals", tags=["Approvals' CRUD"])
+
+
+class ApprovalContent(BaseModel):
+    """Schema for approval content."""
+    status: Literal["accept", "decline", "pending"]
+    kwargs: str
+
+
+class ApprovalOut(BaseModel):
+    """Schema for approval output."""
+    approval_id: str
+    value: ApprovalContent
+    ttl: str
+
+
+class ApprovalUpdate(BaseModel):
+    """Schema for updating an approval."""
+    decision: Literal["accept", "decline"]
+
+
+@router.get("/")
+async def get_approvals(
+    redis_client: Annotated[Redis, Depends(get_redis_client)],
+    user_id: Annotated[str, Depends(get_user_id)],
+) -> list[ApprovalOut]:
+    """Get all pending approvals for a user."""
+    keys = await redis_client.keys(f"approval:{user_id}:*")
+    approvals = []
+
+    pipe = redis_client.pipeline()
+    for key in keys:
+        pipe.get(key)
+        pipe.ttl(key)
+
+    results = await pipe.execute()
+
+    for i in range(0, len(results), 2):
+        value = results[i]
+        ttl = results[i + 1]
+        if value:
+            full_key = keys[i // 2].decode("utf-8")
+            approval_id = full_key.split(":")[-1]
+            value_dict = json.loads(value.decode("utf-8"))
+            content = ApprovalContent(**value_dict)
+            
+            approvals.append(
+                ApprovalOut(
+                    approval_id=approval_id,
+                    value=content,
+                    ttl=str(ttl),
+                )
+            )
+
+    return approvals
+
+
+@router.get("/{approval_id}")
+async def get_approval(
+    approval_id: str,
+    redis_client: Annotated[Redis, Depends(get_redis_client)],
+    user_id: Annotated[str, Depends(get_user_id)],
+) -> ApprovalOut:
+    """Get a specific approval."""
+    key = f"approval:{user_id}:{approval_id}"
+
+    pipe = redis_client.pipeline()
+    pipe.get(key)
+    pipe.ttl(key)
+    value, ttl = await pipe.execute()
+
+    if not value:
+        raise HTTPException(status_code=404, detail="Approval not found")
+
+    value_dict = json.loads(value.decode("utf-8"))
+    content = ApprovalContent(**value_dict)
+
+    return ApprovalOut(
+        approval_id=approval_id,
+        value=content,
+        ttl=str(ttl),
+    )
+
+
+@router.patch("/{approval_id}")
+async def update_approval(
+    approval_id: str,
+    update: ApprovalUpdate,
+    redis_client: Annotated[Redis, Depends(get_redis_client)],
+    user_id: Annotated[str, Depends(get_user_id)],
+) -> ApprovalOut:
+    """Update an approval status."""
+    key = f"approval:{user_id}:{approval_id}"
+    exists = await redis_client.exists(key)
+
+    if not exists:
+        raise HTTPException(status_code=404, detail="Approval not found")
+
+    # Get current value to preserve kwargs
+    current_value = await redis_client.get(key)
+    current_content = json.loads(current_value.decode("utf-8"))
+    
+    # Update status while preserving kwargs
+    new_content = ApprovalContent(
+        status=update.decision,
+        kwargs=current_content['kwargs']
+    )
+    
+    # Save updated content
+    await redis_client.set(key, json.dumps(new_content.model_dump()))
+    ttl = await redis_client.ttl(key)
+    
+    return ApprovalOut(
+        approval_id=approval_id,
+        value=new_content,
+        ttl=str(ttl)
+    )

--- a/swarm_copy/app/routers/approvals.py
+++ b/swarm_copy/app/routers/approvals.py
@@ -23,6 +23,7 @@ class ApprovalContent(BaseModel):
 
     status: Literal["approved", "declined", "pending"]
     parameters: str
+    tool_name: str
 
 
 class ApprovalOut(BaseModel):
@@ -123,9 +124,11 @@ async def update_approval(
     current_value = await redis_client.get(key)
     current_content = json.loads(current_value.decode("utf-8"))
 
-    # Update status while preserving kwargs
+    # Update status while preserving kwargs and tool_name
     new_content = ApprovalContent(
-        status=update.status, parameters=current_content["parameters"]
+        status=update.status,
+        parameters=current_content["parameters"],
+        tool_name=current_content["tool_name"],
     )
 
     # Save updated content and restore TTL

--- a/swarm_copy/app/routers/approvals.py
+++ b/swarm_copy/app/routers/approvals.py
@@ -22,7 +22,7 @@ class ApprovalContent(BaseModel):
     """Schema for approval content."""
 
     status: Literal["approved", "declined", "pending"]
-    kwargs: str
+    parameters: str
 
 
 class ApprovalOut(BaseModel):
@@ -125,7 +125,7 @@ async def update_approval(
 
     # Update status while preserving kwargs
     new_content = ApprovalContent(
-        status=update.status, kwargs=current_content["kwargs"]
+        status=update.status, parameters=current_content["parameters"]
     )
 
     # Save updated content and restore TTL

--- a/swarm_copy/run.py
+++ b/swarm_copy/run.py
@@ -186,7 +186,12 @@ class AgentsRoutine:
                 )
 
                 if not approval_json:
-                    continue
+                    return {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "tool_name": name,
+                        "content": "Tool execution was cancelled due to timeout.",
+                    }, None
 
                 approval = json.loads(approval_json)
                 if approval["status"] == "approved":

--- a/swarm_copy/run.py
+++ b/swarm_copy/run.py
@@ -166,6 +166,7 @@ class AgentsRoutine:
             approval_data = {
                 "status": "pending",
                 "parameters": input_schema.model_dump_json(),
+                "tool_name": name,
             }
             await self.redis_client.set(
                 approval_key, json.dumps(approval_data), ex=self.ttl

--- a/swarm_copy/run.py
+++ b/swarm_copy/run.py
@@ -159,7 +159,7 @@ class AgentsRoutine:
 
         if tool.hil:
             approval_id = str(uuid.uuid4())
-            user_id = context_variables.get("user_id", "default")
+            user_id = context_variables["user_id"]
             approval_key = f"approval:{user_id}:{approval_id}"
 
             # Create initial approval entry

--- a/swarm_copy/run.py
+++ b/swarm_copy/run.py
@@ -165,7 +165,7 @@ class AgentsRoutine:
             # Create initial approval entry
             approval_data = {
                 "status": "pending",
-                "kwargs": input_schema.model_dump_json(),
+                "parameters": input_schema.model_dump_json(),
             }
             await self.redis_client.set(
                 approval_key, json.dumps(approval_data), ex=self.ttl

--- a/swarm_copy/run.py
+++ b/swarm_copy/run.py
@@ -4,9 +4,9 @@ import asyncio
 import copy
 import json
 import logging
+import uuid
 from collections import defaultdict
 from typing import Any, AsyncIterator
-import uuid
 
 import redis.asyncio as redis
 from openai import AsyncOpenAI

--- a/swarm_copy/run.py
+++ b/swarm_copy/run.py
@@ -6,6 +6,7 @@ import json
 from collections import defaultdict
 from typing import Any, AsyncIterator
 
+import redis.asyncio as redis
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionMessage
 from openai.types.chat.chat_completion_message_tool_call import (
@@ -26,7 +27,10 @@ from swarm_copy.utils import merge_chunk
 class AgentsRoutine:
     """Agents routine class. Wrapper for all the functions running the agent."""
 
-    def __init__(self, client: AsyncOpenAI | None = None) -> None:
+    def __init__(
+        self, redis_client: redis.Redis, client: AsyncOpenAI | None = None
+    ) -> None:
+        self.redis_client = redis_client
         if not client:
             client = AsyncOpenAI()
         self.client = client

--- a/swarm_copy/stream.py
+++ b/swarm_copy/stream.py
@@ -21,7 +21,7 @@ async def stream_agent_response(
 ) -> AsyncIterator[str]:
     """Redefine fastAPI connections to enable streaming."""
     if isinstance(agents_routine.client, AsyncOpenAI):
-        connected_agents_routine = AgentsRoutine(
+        connected_agents_routine = AgentsRoutine(  # type: ignore[call-arg]
             client=AsyncOpenAI(api_key=agents_routine.client.api_key)
         )
     else:

--- a/swarm_copy/tools/__init__.py
+++ b/swarm_copy/tools/__init__.py
@@ -19,6 +19,7 @@ from swarm_copy.tools.morphology_features_tool import (
     MorphologyFeatureOutput,
     MorphologyFeatureTool,
 )
+from swarm_copy.tools.now_tool import NowTool
 from swarm_copy.tools.resolve_entities_tool import (
     BRResolveOutput,
     ResolveEntitiesTool,
@@ -42,6 +43,7 @@ __all__ = [
     "MEModelGetOneTool",
     "MorphologyFeatureOutput",
     "MorphologyFeatureTool",
+    "NowTool",
     "ParagraphMetadata",
     "ResolveEntitiesTool",
     "TracesOutput",

--- a/swarm_copy/tools/base_tool.py
+++ b/swarm_copy/tools/base_tool.py
@@ -66,6 +66,7 @@ class BaseTool(BaseModel, ABC):
 
     name: ClassVar[str]
     description: ClassVar[str]
+    hil: ClassVar[bool] = False
     metadata: BaseMetadata
     input_schema: BaseModel
 

--- a/swarm_copy/tools/now_tool.py
+++ b/swarm_copy/tools/now_tool.py
@@ -1,0 +1,41 @@
+"""Get the current time in the UTC timezone in the format of ISO 8601."""
+
+import datetime
+import logging
+from typing import ClassVar
+
+from pydantic import BaseModel
+from swarm_copy.tools.base_tool import BaseMetadata, BaseTool
+
+
+logger = logging.getLogger(__name__)
+
+
+class NowMetadata(BaseMetadata):
+    """Metadata for tool calling."""
+
+
+class NowInput(BaseModel):
+    """Input for tool calling."""
+
+
+class NowTool(BaseTool):
+    """Thought count tool for calling."""
+
+    name: ClassVar[str] = "get-now"
+    description: ClassVar[str] = (
+        "This tool returns the current time in the UTC timezone in the format of ISO 8601."
+    )
+    hil: ClassVar[bool] = True
+    metadata: NowMetadata
+    input_schema: NowInput
+
+    def run(self) -> str:
+        """Run the tool."""
+        raise NotImplementedError
+
+    async def arun(self) -> str:
+        """Run the tool asynchronously."""
+        logger.info("Calling the now tool")
+
+        return datetime.datetime.now(datetime.timezone.utc).isoformat()

--- a/swarm_copy/tools/now_tool.py
+++ b/swarm_copy/tools/now_tool.py
@@ -5,8 +5,8 @@ import logging
 from typing import ClassVar
 
 from pydantic import BaseModel
-from swarm_copy.tools.base_tool import BaseMetadata, BaseTool
 
+from swarm_copy.tools.base_tool import BaseMetadata, BaseTool
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# How to test?

First of all, spin up `redis`


```shell
$ docker run -p 6380:6379 -d redis
```

And then add the following entry to your `.env`

```shell
NEUROAGENT_HIL__REDIS_URI=redis://localhost:6380
```

I added a `get-now` tool that is the only tool that has the `hil: True`. 


```bash
$ curl -X POST -H "content-type: application/json" -H "x-project-id: $PROJECT_ID" -H "x-virtual-lab-id: $VIRTUAL_LAB_ID" -H "Authorization: Bearer $TOKEN" -d '{"query": "Could you please call the get-now tool three times as the same time"}' 'localhost:8001/qa/run/' | jq 
```

You can then use the `approvals` router and the endpoint to view and decline/approve outstanding requests.